### PR TITLE
fix: staffのパスワードを専用のものに修正

### DIFF
--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -29,7 +29,7 @@ class UserSeeder extends Seeder
             [
                 'name'     => 'staff',
                 'email'    => 'staff@staff.com',
-                'password' => Hash::make(env('USER_PASSWORD')),
+                'password' => Hash::make(env('STAFF_PASSWORD')),
                 'role'     => 5,
             ],
             [


### PR DESCRIPTION
## 目的
UserSeederのstaffのパスワード部分を用意したキーに修正。

## 変更点

このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- 変更点1
staffのパスワードに.envのSTAFF_PASSWORDの値を使用するよう変更。